### PR TITLE
Changing some services from beta to live

### DIFF
--- a/lib/projects/ia-fws.js
+++ b/lib/projects/ia-fws.js
@@ -1,7 +1,7 @@
 {
   "id":110,
   "name":"Flood Warning System",
-  "description": "Replacement of the direct warning messaging service to over 1.1 million customers at risk of flooding across a crange of channels.",
+  "description": "Replacement of the direct warning messaging service to over 1.1 million customers at risk of flooding across a range of channels.",
   "theme": "Incidents & Assets Services",
   "location": "Crewe",
   "phase":"beta",

--- a/lib/projects/ia-lfw.js
+++ b/lib/projects/ia-lfw.js
@@ -4,7 +4,7 @@
   "description": "To provide timely flood warnings to the public and service partners",
   "theme": "Incidents & Assets Services",
   "location": "Warrington",
-  "phase":"beta",
+  "phase":"live",
   "phase_modifier":"public",
   "sro":"Craig Woolhouse",
   "service_man":"Andy Wilkinson",
@@ -31,7 +31,7 @@
       {"label":"Public beta released", "date": "April 2015"}
     ],
     "live": [
-      {"label":"Predicted live release date", "date": "August 2016"}
+      {"label":"Live released", "date": "Septemeber 2016"}
     ]
   },
   "priority":"High",

--- a/lib/projects/ia-lfw.js
+++ b/lib/projects/ia-lfw.js
@@ -31,7 +31,7 @@
       {"label":"Public beta released", "date": "April 2015"}
     ],
     "live": [
-      {"label":"Live released", "date": "Septemeber 2016"}
+      {"label":"Live released", "date": "September 2016"}
     ]
   },
   "priority":"High",

--- a/lib/projects/ia-rloi.js
+++ b/lib/projects/ia-rloi.js
@@ -31,7 +31,7 @@
       {"label":"Public beta released", "date": "January 2016"}
     ],
     "live": [
-      {"label":"Live releases", "date": "September 2016"}
+      {"label":"Live released", "date": "September 2016"}
     ]
   },
   "priority":"Medium",

--- a/lib/projects/ia-rloi.js
+++ b/lib/projects/ia-rloi.js
@@ -4,7 +4,7 @@
   "description": "To inform the public and businesses of river level heights and associated local flood risk.",
   "theme": "Incidents & Assets Services",
   "location": "Warrington",
-  "phase":"beta",
+  "phase":"live",
   "phase_modifier":"public",
   "sro":"Craig Woolhouse",
   "service_man":"Andy Wilkinson",
@@ -31,9 +31,9 @@
       {"label":"Public beta released", "date": "January 2016"}
     ],
     "live": [
-      {"label":"Predicted live release", "date": "August 2016"}
+      {"label":"Live releases", "date": "September 2016"}
     ]
   },
   "priority":"Medium",
-  "service":"https://flood-warning-information.service.gov.uk/"
+  "service":"https://flood-warning-information.service.gov.uk/river-and-sea-levels"
   }


### PR DESCRIPTION
A couple of these flood related services are now live - Flood Information service and the Rivers and Sea Levels. My changes reflect these updates from Sept 2016.
