### PR TITLE
Update to the water resource licensing service

### DIFF
--- a/lib/id_tracker.txt
+++ b/lib/id_tracker.txt
@@ -9,7 +9,7 @@
   108 - Flood Forecasting Service
   109 - Flood Asset Management - CAMC
   110 - Flood Warning System
-  111 - Water resource licensing service
+  111 - 
   112 - 
   113 - 
 200 - Permissions & Compliance Services
@@ -22,7 +22,9 @@
   207 - Flood risk assessment exemptions
   208 - Waste Policy & Delivery Challenge
   209 - Waste carriers
-  210 - 
+  210 - Water resource licensing service
+  211 - 
+  212 - 
 300 - Livestock Information Services
   301 - Animal disease testing service
   302 - Livestock Information - Policy & Delivery Challenge
@@ -42,6 +44,7 @@
   504 - Extreme Data Transfer
   505 - Farm Visits
   506 - People Finder
+  507 - 
 600 - Common Architectural Services
   601 - Data ETL
   602 - Integration Platform

--- a/lib/projects/pc-water.js
+++ b/lib/projects/pc-water.js
@@ -1,6 +1,6 @@
 
 {
-  "id":111,
+  "id":210,
   "name":"Water resource licensing service",
   "description": "More efficient and effective water abstraction and impoundment licencing service.",
   "theme": "Permissions & Compliance Services",


### PR DESCRIPTION
This is a small update that moves the water resource licensing service to a more appropriate area in the id tracker file (Permissions & Compliance Services)